### PR TITLE
fixed typo that precents client.mkdirs() to do anything useful

### DIFF
--- a/easywebdav2/client.py
+++ b/easywebdav2/client.py
@@ -145,7 +145,7 @@ class Client(object):
         try:
             for dir_ in dirs:
                 try:
-                    self.mkdir(dir, safe=True, **kwargs)
+                    self.mkdir(dir_, safe=True, **kwargs)
                 except Exception as e:
                     if e.actual_code == 409:
                         raise


### PR DESCRIPTION
the current implementation of `client.mkdirs()` has a typo where it passes `dir` as the path to `client.mkdir()` rather than `dir_`, which results in the call trying to create directories named `.../<built-in function dir>` (which is the string-representatio nof the built-in function `dir`).

it would be nice if you could also do a release after fixing that... :-)